### PR TITLE
Fix crashes due to answer and option parsing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,8 @@
         "remark-gfm": "^3.0.1",
         "unified": "^10.1.2",
         "unist-builder": "^4.0.0",
-        "unist-util-find-after": "^5.0.0"
+        "unist-util-find-after": "^5.0.0",
+        "unist-util-is": "^6.0.0"
       },
       "devDependencies": {
         "@types/js-yaml": "^4.0.5",
@@ -2483,6 +2484,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/mdast-util-find-and-replace/node_modules/unist-util-is": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.2.1.tgz",
+      "integrity": "sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==",
+      "dependencies": {
+        "@types/unist": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdast-util-from-markdown": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-1.3.1.tgz",
@@ -2633,6 +2646,18 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/mdast-util-gfm-footnote/node_modules/unist-util-is": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.2.1.tgz",
+      "integrity": "sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==",
+      "dependencies": {
+        "@types/unist": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdast-util-gfm-strikethrough": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-1.0.3.tgz",
@@ -2692,6 +2717,18 @@
       "integrity": "sha512-V4Zn/ncyN1QNSqSBxTrMOLpjr+IKdHl2v3KVLoWmDPscP4r9GcCi71gjgvUV1SFSKh92AjAG4peFuBl2/YgCJg==",
       "dependencies": {
         "@types/mdast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough/node_modules/unist-util-is": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.2.1.tgz",
+      "integrity": "sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==",
+      "dependencies": {
+        "@types/unist": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2765,6 +2802,18 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/mdast-util-gfm-table/node_modules/unist-util-is": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.2.1.tgz",
+      "integrity": "sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==",
+      "dependencies": {
+        "@types/unist": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdast-util-gfm-task-list-item": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-1.0.2.tgz",
@@ -2830,6 +2879,18 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/mdast-util-gfm-task-list-item/node_modules/unist-util-is": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.2.1.tgz",
+      "integrity": "sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==",
+      "dependencies": {
+        "@types/unist": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdast-util-gfm/node_modules/@types/mdast": {
       "version": "3.0.12",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.12.tgz",
@@ -2882,6 +2943,18 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/mdast-util-gfm/node_modules/unist-util-is": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.2.1.tgz",
+      "integrity": "sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==",
+      "dependencies": {
+        "@types/unist": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdast-util-phrasing": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.0.0.tgz",
@@ -2889,23 +2962,6 @@
       "dependencies": {
         "@types/mdast": "^4.0.0",
         "unist-util-is": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/mdast-util-phrasing/node_modules/@types/unist": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.0.tgz",
-      "integrity": "sha512-MFETx3tbTjE7Uk6vvnWINA/1iJ7LuMdO4fcq8UfF0pRbj01aGLduVvQcRyswuACJdpnHgg8E3rQLhaRdNEJS0w=="
-    },
-    "node_modules/mdast-util-phrasing/node_modules/unist-util-is": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
-      "integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
-      "dependencies": {
-        "@types/unist": "^3.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -3050,18 +3106,6 @@
           "url": "https://opencollective.com/unified"
         }
       ]
-    },
-    "node_modules/mdast-util-to-markdown/node_modules/unist-util-is": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
-      "integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
-      "dependencies": {
-        "@types/unist": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
     },
     "node_modules/mdast-util-to-markdown/node_modules/unist-util-visit": {
       "version": "5.0.0",
@@ -4654,7 +4698,16 @@
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.0.tgz",
       "integrity": "sha512-MFETx3tbTjE7Uk6vvnWINA/1iJ7LuMdO4fcq8UfF0pRbj01aGLduVvQcRyswuACJdpnHgg8E3rQLhaRdNEJS0w=="
     },
-    "node_modules/unist-util-find-after/node_modules/unist-util-is": {
+    "node_modules/unist-util-generated": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-generated/-/unist-util-generated-2.0.1.tgz",
+      "integrity": "sha512-qF72kLmPxAw0oN2fwpWIqbXAVyEqUzDHMsbtPvOudIlUzXYFIeQIuxXQCRCFh22B7cixvU0MG7m3MW8FTq/S+A==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
       "integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
@@ -4666,26 +4719,10 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/unist-util-generated": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/unist-util-generated/-/unist-util-generated-2.0.1.tgz",
-      "integrity": "sha512-qF72kLmPxAw0oN2fwpWIqbXAVyEqUzDHMsbtPvOudIlUzXYFIeQIuxXQCRCFh22B7cixvU0MG7m3MW8FTq/S+A==",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/unist-util-is": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.2.1.tgz",
-      "integrity": "sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==",
-      "dependencies": {
-        "@types/unist": "^2.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
+    "node_modules/unist-util-is/node_modules/@types/unist": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.0.tgz",
+      "integrity": "sha512-MFETx3tbTjE7Uk6vvnWINA/1iJ7LuMdO4fcq8UfF0pRbj01aGLduVvQcRyswuACJdpnHgg8E3rQLhaRdNEJS0w=="
     },
     "node_modules/unist-util-position": {
       "version": "4.0.4",
@@ -4732,6 +4769,30 @@
       "dependencies": {
         "@types/unist": "^2.0.0",
         "unist-util-is": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents/node_modules/unist-util-is": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.2.1.tgz",
+      "integrity": "sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==",
+      "dependencies": {
+        "@types/unist": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit/node_modules/unist-util-is": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.2.1.tgz",
+      "integrity": "sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==",
+      "dependencies": {
+        "@types/unist": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -6663,6 +6724,14 @@
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
           "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="
+        },
+        "unist-util-is": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.2.1.tgz",
+          "integrity": "sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==",
+          "requires": {
+            "@types/unist": "^2.0.0"
+          }
         }
       }
     },
@@ -6756,6 +6825,14 @@
           "requires": {
             "@types/mdast": "^3.0.0"
           }
+        },
+        "unist-util-is": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.2.1.tgz",
+          "integrity": "sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==",
+          "requires": {
+            "@types/unist": "^2.0.0"
+          }
         }
       }
     },
@@ -6829,6 +6906,14 @@
           "requires": {
             "@types/mdast": "^3.0.0"
           }
+        },
+        "unist-util-is": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.2.1.tgz",
+          "integrity": "sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==",
+          "requires": {
+            "@types/unist": "^2.0.0"
+          }
         }
       }
     },
@@ -6879,6 +6964,14 @@
           "integrity": "sha512-V4Zn/ncyN1QNSqSBxTrMOLpjr+IKdHl2v3KVLoWmDPscP4r9GcCi71gjgvUV1SFSKh92AjAG4peFuBl2/YgCJg==",
           "requires": {
             "@types/mdast": "^3.0.0"
+          }
+        },
+        "unist-util-is": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.2.1.tgz",
+          "integrity": "sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==",
+          "requires": {
+            "@types/unist": "^2.0.0"
           }
         }
       }
@@ -6933,6 +7026,14 @@
           "requires": {
             "@types/mdast": "^3.0.0"
           }
+        },
+        "unist-util-is": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.2.1.tgz",
+          "integrity": "sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==",
+          "requires": {
+            "@types/unist": "^2.0.0"
+          }
         }
       }
     },
@@ -6984,6 +7085,14 @@
           "requires": {
             "@types/mdast": "^3.0.0"
           }
+        },
+        "unist-util-is": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.2.1.tgz",
+          "integrity": "sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==",
+          "requires": {
+            "@types/unist": "^2.0.0"
+          }
         }
       }
     },
@@ -6994,21 +7103,6 @@
       "requires": {
         "@types/mdast": "^4.0.0",
         "unist-util-is": "^6.0.0"
-      },
-      "dependencies": {
-        "@types/unist": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.0.tgz",
-          "integrity": "sha512-MFETx3tbTjE7Uk6vvnWINA/1iJ7LuMdO4fcq8UfF0pRbj01aGLduVvQcRyswuACJdpnHgg8E3rQLhaRdNEJS0w=="
-        },
-        "unist-util-is": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
-          "integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
-          "requires": {
-            "@types/unist": "^3.0.0"
-          }
-        }
       }
     },
     "mdast-util-to-hast": {
@@ -7093,14 +7187,6 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.0.tgz",
           "integrity": "sha512-oNh6S2WMHWRZrmutsRmDDfkzKtxF+bc2VxLC9dvtrDIRFln627VsFP6fLMgTryGDljgLPjkrzQSDcPrjPyDJ5w=="
-        },
-        "unist-util-is": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
-          "integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
-          "requires": {
-            "@types/unist": "^3.0.0"
-          }
         },
         "unist-util-visit": {
           "version": "5.0.0",
@@ -8164,14 +8250,6 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.0.tgz",
           "integrity": "sha512-MFETx3tbTjE7Uk6vvnWINA/1iJ7LuMdO4fcq8UfF0pRbj01aGLduVvQcRyswuACJdpnHgg8E3rQLhaRdNEJS0w=="
-        },
-        "unist-util-is": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
-          "integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
-          "requires": {
-            "@types/unist": "^3.0.0"
-          }
         }
       }
     },
@@ -8181,11 +8259,18 @@
       "integrity": "sha512-qF72kLmPxAw0oN2fwpWIqbXAVyEqUzDHMsbtPvOudIlUzXYFIeQIuxXQCRCFh22B7cixvU0MG7m3MW8FTq/S+A=="
     },
     "unist-util-is": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.2.1.tgz",
-      "integrity": "sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
+      "integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
       "requires": {
-        "@types/unist": "^2.0.0"
+        "@types/unist": "^3.0.0"
+      },
+      "dependencies": {
+        "@types/unist": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.0.tgz",
+          "integrity": "sha512-MFETx3tbTjE7Uk6vvnWINA/1iJ7LuMdO4fcq8UfF0pRbj01aGLduVvQcRyswuACJdpnHgg8E3rQLhaRdNEJS0w=="
+        }
       }
     },
     "unist-util-position": {
@@ -8212,6 +8297,16 @@
         "@types/unist": "^2.0.0",
         "unist-util-is": "^5.0.0",
         "unist-util-visit-parents": "^5.1.1"
+      },
+      "dependencies": {
+        "unist-util-is": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.2.1.tgz",
+          "integrity": "sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==",
+          "requires": {
+            "@types/unist": "^2.0.0"
+          }
+        }
       }
     },
     "unist-util-visit-parents": {
@@ -8221,6 +8316,16 @@
       "requires": {
         "@types/unist": "^2.0.0",
         "unist-util-is": "^5.0.0"
+      },
+      "dependencies": {
+        "unist-util-is": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.2.1.tgz",
+          "integrity": "sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==",
+          "requires": {
+            "@types/unist": "^2.0.0"
+          }
+        }
       }
     },
     "uri-js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "@typescript-eslint/eslint-plugin": "^6.0.0",
         "@typescript-eslint/parser": "^6.0.0",
         "@vitejs/plugin-react-swc": "^3.3.2",
+        "dedent": "^1.5.1",
         "eslint": "^8.45.0",
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-react-refresh": "^0.4.3",
@@ -1491,6 +1492,20 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/dedent": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.5.1.tgz",
+      "integrity": "sha512-+LxW+KLWxu3HW3M2w2ympwtqPrqYRzU8fqi6Fhd18fBALe15blJPI/I4+UHveMVG6lJqB4JNd4UG0S5cnVHwIg==",
+      "dev": true,
+      "peerDependencies": {
+        "babel-plugin-macros": "^3.1.0"
+      },
+      "peerDependenciesMeta": {
+        "babel-plugin-macros": {
+          "optional": true
+        }
       }
     },
     "node_modules/deep-eql": {
@@ -5998,6 +6013,13 @@
       "requires": {
         "character-entities": "^2.0.0"
       }
+    },
+    "dedent": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.5.1.tgz",
+      "integrity": "sha512-+LxW+KLWxu3HW3M2w2ympwtqPrqYRzU8fqi6Fhd18fBALe15blJPI/I4+UHveMVG6lJqB4JNd4UG0S5cnVHwIg==",
+      "dev": true,
+      "requires": {}
     },
     "deep-eql": {
       "version": "4.1.3",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "remark-gfm": "^3.0.1",
     "unified": "^10.1.2",
     "unist-builder": "^4.0.0",
-    "unist-util-find-after": "^5.0.0"
+    "unist-util-find-after": "^5.0.0",
+    "unist-util-is": "^6.0.0"
   },
   "devDependencies": {
     "@types/js-yaml": "^4.0.5",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@typescript-eslint/eslint-plugin": "^6.0.0",
     "@typescript-eslint/parser": "^6.0.0",
     "@vitejs/plugin-react-swc": "^3.3.2",
+    "dedent": "^1.5.1",
     "eslint": "^8.45.0",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.3",

--- a/src/components/document.tsx
+++ b/src/components/document.tsx
@@ -8,6 +8,7 @@ import remarkCallout from '../remark-plugins/remark-callout-plugin';
 import remarkChallenges from '../remark-plugins/remark-challenge-plugin';
 import remarkFixUrls from '../remark-plugins/remark-fix-urls-plugin';
 import remarkFixListsWithCode from '../remark-plugins/remark-fix-lists-with-code-plugin';
+import { fixBadCodeIndentInList } from '../remark-plugins/preprocess-fix-bad-code-indent';
 
 import '../remark-plugins/remark-callout-plugin.css';
 import { ClearMarkdownAction } from '../reducers/markdown-actions';
@@ -54,6 +55,10 @@ function Document() {
     );
   }
 
+  // Preprocess the markdown.
+  // Some markdown files have bad code indents that need to be fixed up before parsing.
+  const renderableMarkdown = fixBadCodeIndentInList(mdState.currentMarkdown);
+
   return (
     <div id="markdown-container">
       <div className='right-align'>
@@ -90,7 +95,7 @@ function Document() {
             }
           }}
         >
-          {mdState.currentMarkdown}
+          { renderableMarkdown }
         </ReactMarkdown>
       </ErrorBoundary>
     </div>

--- a/src/components/document.tsx
+++ b/src/components/document.tsx
@@ -7,6 +7,7 @@ import rehypeExternalLinks from 'rehype-external-links';
 import remarkCallout from '../remark-plugins/remark-callout-plugin';
 import remarkChallenges from '../remark-plugins/remark-challenge-plugin';
 import remarkFixUrls from '../remark-plugins/remark-fix-urls-plugin';
+import remarkFixListsWithCode from '../remark-plugins/remark-fix-lists-with-code-plugin';
 
 import '../remark-plugins/remark-callout-plugin.css';
 import { ClearMarkdownAction } from '../reducers/markdown-actions';
@@ -61,10 +62,11 @@ function Document() {
       <ErrorBoundary fallback={<div>The Markdown failed to load</div>}>
         <ReactMarkdown
           remarkPlugins={[
+            [remarkFixUrls, { rootUrl: mdState.markdownRootUrl }],
             remarkGfm,
+            remarkFixListsWithCode,
             remarkCallout,
             remarkChallenges,
-            [remarkFixUrls, { rootUrl: mdState.markdownRootUrl }]
           ]}
           rehypePlugins={[
             rehypeRaw,

--- a/src/remark-plugins/preprocess-fix-bad-code-indent.test.ts
+++ b/src/remark-plugins/preprocess-fix-bad-code-indent.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest';
+import { fixBadCodeIndentInList } from "./preprocess-fix-bad-code-indent";
+
+const input: string = `
+* \`\`\`python
+for counter in range(4):
+    print(counter)
+\`\`\`
+
+* Another list item
+  with some content in it
+
+*
+Some stuff below an empty list
+
+* \`\`\`python
+for counter in range(5):
+    print(counter)
+\`\`\`
+
+* \`\`\`python
+for counter in range(5, 0):
+    print(counter)
+\`\`\`
+
+\`\`\`python
+A code block just hanging out
+\`\`\`
+
+* \`\`\`python
+for counter in range(5, 0, -1):
+    print(counter)
+\`\`\`
+`;
+
+const expected: string = `
+* \`\`\`python
+  for counter in range(4):
+      print(counter)
+  \`\`\`
+
+* Another list item
+  with some content in it
+
+*
+Some stuff below an empty list
+
+* \`\`\`python
+  for counter in range(5):
+      print(counter)
+  \`\`\`
+
+* \`\`\`python
+  for counter in range(5, 0):
+      print(counter)
+  \`\`\`
+
+\`\`\`python
+A code block just hanging out
+\`\`\`
+
+* \`\`\`python
+  for counter in range(5, 0, -1):
+      print(counter)
+  \`\`\`
+`;
+
+describe('preprocess-fix-bad-code-indent', () => {
+  it('fixes bad code indent in one list items', () => {
+    const input = `
+* \`\`\`python
+for counter in range(4):
+    print(counter)
+\`\`\`
+`;
+
+    const expected = `
+* \`\`\`python
+  for counter in range(4):
+      print(counter)
+  \`\`\`
+`;
+    const result = fixBadCodeIndentInList(input);
+    expect(result).toEqual(expected);
+  });
+
+  it('fixes bad code indent in many list items', () => {
+    const result = fixBadCodeIndentInList(input);
+    expect(result).toEqual(expected);
+  });
+
+  it('ignores already good code indent', () => {
+    const input = `
+* \`\`\`python
+  for counter in range(4):
+      print(counter)
+  \`\`\`
+`;
+
+    const result = fixBadCodeIndentInList(input);
+    expect(result).toEqual(input);
+  });
+});

--- a/src/remark-plugins/preprocess-fix-bad-code-indent.test.ts
+++ b/src/remark-plugins/preprocess-fix-bad-code-indent.test.ts
@@ -100,4 +100,29 @@ for counter in range(4):
     const result = fixBadCodeIndentInList(input);
     expect(result).toEqual(input);
   });
+
+  it(`indents if the code block finishes on the next line`, () => {
+    const input = `
+* \`\`\`python for counter in range(4): print(counter)
+\`\`\`
+`;
+    const expected = `
+* \`\`\`python for counter in range(4): print(counter)
+  \`\`\`
+`;
+    const result = fixBadCodeIndentInList(input);
+    expect(result).toEqual(expected);
+  });
+
+  it(`correctly handles code blocks on a single line`, () => {
+    const input = `
+* \`\`\`python for counter in range(4): print(counter)\`\`\`
+\`\`\`
+def perfectly_valid_code():
+    return "because it's a separate code block.";
+\`\`\`
+`;
+    const result = fixBadCodeIndentInList(input);
+    expect(result).toEqual(input);
+  });
 });

--- a/src/remark-plugins/preprocess-fix-bad-code-indent.test.ts
+++ b/src/remark-plugins/preprocess-fix-bad-code-indent.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import dedent from 'dedent';
 import { fixBadCodeIndentInList } from "./preprocess-fix-bad-code-indent";
 
 const input: string = `
@@ -67,19 +68,19 @@ A code block just hanging out
 
 describe('preprocess-fix-bad-code-indent', () => {
   it('fixes bad code indent in one list items', () => {
-    const input = `
-* \`\`\`python
-for counter in range(4):
-    print(counter)
-\`\`\`
-`;
+    const input = dedent`
+      * \`\`\`python
+      for counter in range(4):
+          print(counter)
+      \`\`\`
+      `;
 
-    const expected = `
-* \`\`\`python
-  for counter in range(4):
-      print(counter)
-  \`\`\`
-`;
+    const expected = dedent`
+      * \`\`\`python
+        for counter in range(4):
+            print(counter)
+        \`\`\`
+      `;
     const result = fixBadCodeIndentInList(input);
     expect(result).toEqual(expected);
   });
@@ -90,38 +91,38 @@ for counter in range(4):
   });
 
   it('ignores already good code indent', () => {
-    const input = `
-* \`\`\`python
-  for counter in range(4):
-      print(counter)
-  \`\`\`
-`;
+    const input = dedent`
+      * \`\`\`python
+        for counter in range(4):
+            print(counter)
+        \`\`\`
+      `;
 
     const result = fixBadCodeIndentInList(input);
     expect(result).toEqual(input);
   });
 
   it(`indents if the code block finishes on the next line`, () => {
-    const input = `
-* \`\`\`python for counter in range(4): print(counter)
-\`\`\`
-`;
-    const expected = `
-* \`\`\`python for counter in range(4): print(counter)
-  \`\`\`
-`;
+    const input = dedent`
+      * \`\`\`python for counter in range(4): print(counter)
+      \`\`\`
+      `;
+    const expected = dedent`
+      * \`\`\`python for counter in range(4): print(counter)
+        \`\`\`
+      `;
     const result = fixBadCodeIndentInList(input);
     expect(result).toEqual(expected);
   });
 
   it(`correctly handles code blocks on a single line`, () => {
-    const input = `
-* \`\`\`python for counter in range(4): print(counter)\`\`\`
-\`\`\`
-def perfectly_valid_code():
-    return "because it's a separate code block.";
-\`\`\`
-`;
+    const input = dedent`
+      * \`\`\`python for counter in range(4): print(counter)\`\`\`
+      \`\`\`
+      def perfectly_valid_code():
+          return "because it's a separate code block.";
+      \`\`\`
+      `;
     const result = fixBadCodeIndentInList(input);
     expect(result).toEqual(input);
   });

--- a/src/remark-plugins/preprocess-fix-bad-code-indent.ts
+++ b/src/remark-plugins/preprocess-fix-bad-code-indent.ts
@@ -1,0 +1,33 @@
+export function fixBadCodeIndentInList(markdown: string): string {
+  // Match a list item that starts with a code block, followed by any number of lines that are missing
+  // indentation at two spaces, followed by the end of the code block.
+  const lines = markdown.split('\n');
+  let currentLine = 0;
+  while (currentLine < lines.length) {
+    currentLine = fixFirstBadCodeIndentInList(lines, currentLine);
+  }
+
+  markdown = lines.join('\n');
+  return markdown;
+}
+
+function fixFirstBadCodeIndentInList(lines: string[], startingLine: number): number {
+  const idxCodeStart = lines.findIndex((line, idx) => idx > startingLine && line.match(/^[*-] ```/));
+  if (idxCodeStart === -1) {
+    return lines.length;
+  }
+
+  if (lines[idxCodeStart].match(/^[*-] ```.*```/)) {
+    // The code block is on a single line, so there's nothing to fix. Skip to the next line after it.
+    return idxCodeStart + 1;
+  }
+
+  const idxCodeEnd = lines.findIndex((line, idx) => idx > idxCodeStart && line.match(/```/));
+  const needsIndent = lines.slice(idxCodeStart + 1, idxCodeEnd).some(line => !line.startsWith('  '));
+  if (needsIndent) {
+    for (let i = idxCodeStart + 1; i <= idxCodeEnd; i++) {
+      lines[i] = '  ' + lines[i];
+    }
+  }
+  return idxCodeEnd + 1;
+}

--- a/src/remark-plugins/preprocess-fix-bad-code-indent.ts
+++ b/src/remark-plugins/preprocess-fix-bad-code-indent.ts
@@ -12,7 +12,7 @@ export function fixBadCodeIndentInList(markdown: string): string {
 }
 
 function fixFirstBadCodeIndentInList(lines: string[], startingLine: number): number {
-  const idxCodeStart = lines.findIndex((line, idx) => idx > startingLine && line.match(/^[*-] ```/));
+  const idxCodeStart = lines.findIndex((line, idx) => idx >= startingLine && line.match(/^[*-] ```/));
   if (idxCodeStart === -1) {
     return lines.length;
   }

--- a/src/remark-plugins/preprocess-fix-bad-code-indent.ts
+++ b/src/remark-plugins/preprocess-fix-bad-code-indent.ts
@@ -23,7 +23,7 @@ function fixFirstBadCodeIndentInList(lines: string[], startingLine: number): num
   }
 
   const idxCodeEnd = lines.findIndex((line, idx) => idx > idxCodeStart && line.match(/```/));
-  const needsIndent = lines.slice(idxCodeStart + 1, idxCodeEnd).some(line => !line.startsWith('  '));
+  const needsIndent = lines.slice(idxCodeStart + 1, idxCodeEnd + 1).some(line => !line.startsWith('  '));
   if (needsIndent) {
     for (let i = idxCodeStart + 1; i <= idxCodeEnd; i++) {
       lines[i] = '  ' + lines[i];

--- a/src/remark-plugins/remark-challenge-plugin/index.ts
+++ b/src/remark-plugins/remark-challenge-plugin/index.ts
@@ -84,7 +84,7 @@ function getAnswerIds(answer: Node[], challengeInfo: ChallengeInfo, mdToIdMap: M
   }
 
   // If this is a single paragraph node, that's the answer.
-  if (answer.length === 1 && is(answer[0], 'paragraph')) {
+  if (answer.length === 1 && (is(answer[0], 'paragraph') || is(answer[0], 'code') || is(answer[0], 'text'))) {
     return [getAnswerId(answer[0] as Paragraph)];
   }
 

--- a/src/remark-plugins/remark-challenge-plugin/make-option.ts
+++ b/src/remark-plugins/remark-challenge-plugin/make-option.ts
@@ -1,5 +1,5 @@
 import { type Node } from 'unist';
-import { List, ListItem, Paragraph } from 'mdast';
+import { List, ListItem, Paragraph, Code, Text } from 'mdast';
 import { toMarkdown } from 'mdast-util-to-markdown';
 import { makeMdToHastNode, GeneratedNode } from './generate-node';
 import { ChallengeInfo } from './md-to-js-parse';
@@ -77,15 +77,22 @@ function makeCheckbox(option: Node, challenge: ChallengeInfo): GeneratedNode {
  * @param node A node that may be a Paragraph or a ListItem
  * @returns The Paragraph inside the ListItem or the Paragraph, depending on which was passed in.
  */
-export function unList(node: Node): Paragraph {
+export function unList(node: Node): Paragraph | Code | Text {
   if (node.type === 'paragraph') { return node as Paragraph; }
+  if (node.type === 'code') { return node as Code; }
+  if (node.type === 'text') { return node as Text; }
   if (node.type !== 'listItem') {
-    throw new Error('Expected a list or paragraph');
+    throw new Error('Expected a list or paragraph/code/text');
   }
 
   const listItem = node as ListItem;
-  if (listItem.children.length !== 1 && listItem.children[0].type !== 'paragraph') {
-    throw new Error('Expected a list with a single paragraph');
+  if (listItem.children.length !== 1) {
+    throw new Error('Expected a list with a single paragraph/code');
   }
-  return listItem.children[0] as Paragraph;
+
+  const firstchild = listItem.children[0];
+  if (firstchild.type === 'paragraph') { return firstchild as Paragraph; }
+  if (firstchild.type === 'code') { return firstchild as Code; }
+
+  throw new Error(`Expected a list with a single paragraph/code, but it had type '${firstchild.type}'`);
 }

--- a/src/remark-plugins/remark-fix-lists-with-code-plugin.ts
+++ b/src/remark-plugins/remark-fix-lists-with-code-plugin.ts
@@ -1,0 +1,58 @@
+/**
+ * A remark plugin that finds code blocks that are poorly formed and correctly nests them into the lists
+ * that they are supposed to be in.
+ */
+import { visit, CONTINUE, type Visitor, type VisitorResult } from 'unist-util-visit';
+import { is } from 'unist-util-is';
+import type { Transformer, Plugin } from 'unified';
+import type { Parent } from 'unist';
+import type { Root, Code, List } from 'mdast';
+
+interface FixCodeListOptions {
+}
+
+/**
+ * This plugin transforms relative URLs to absolute URLs. *
+ */
+export const plugin: Plugin<[FixCodeListOptions?], Root> = () => {
+  const visitor: Visitor<List> = (node: List, index: number | null, parent: Parent | null): VisitorResult => {
+    if (parent === null || index === null) return CONTINUE;
+
+    // The list has a list item, but it's empty. See if a code block comes after it as a sibling.
+    // If it does, move the code block into the list item.
+    if (is(node.children[0], 'listItem') && node.children[0].children.length === 0) {
+      const listItem = node.children[0];
+      if (is(parent.children[index + 1], 'code')) {
+        const code = parent.children[index + 1] as Code;
+        listItem.children.push(code);
+        parent.children.splice(index + 1, 1);
+      }
+    }
+  
+    return CONTINUE;
+  };
+
+  const listCoalescingVisitor: Visitor<List> = (node: List, index: number | null, parent: Parent | null): VisitorResult => {
+    if (parent === null || index === null) return CONTINUE;
+
+    // While this list is followed by other lists, coalesce them into this list.
+    while (is(parent.children[index + 1], 'list')) {
+      const nextList = parent.children[index + 1] as List;
+      node.children.push(...nextList.children);
+      parent.children.splice(index + 1, 1);
+    }
+
+    return CONTINUE;
+  };
+
+  const transformer: Transformer<Root, Root> = (tree: Root) => {
+    visit(tree, 'list', visitor);
+    visit(tree, 'list', listCoalescingVisitor);
+  };
+
+  return transformer;
+};
+
+
+
+export default plugin;

--- a/src/remark-plugins/remark-fix-urls-plugin.ts
+++ b/src/remark-plugins/remark-fix-urls-plugin.ts
@@ -20,7 +20,7 @@ export const plugin: Plugin<[FixUrlOptions?], Root> = (options) => {
 
     if (!rNode?.url.startsWith('http')) {
       const withoutFile = options?.rootUrl.slice(0, options?.rootUrl.lastIndexOf('/') + 1);
-      console.log(withoutFile, rNode.url);
+      console.log('Updating URL:', withoutFile, rNode.url);
       rNode.url = withoutFile + rNode.url;
     }
   


### PR DESCRIPTION
## Description
Fixes #9 

A couple of different potential issues can happen with options that have lists where there are code blocks:
1. The author may have created empty list items with code blocks that follow them, e.g.
   ~~~md
   *
   ```python
   def some_fun():
      return
   ```
   ~~~
2. The author may also have indented incorrectly, e.g.:
   ~~~md
   * ```python
   def some_fun():
     return
   ```
   ~~~

We can fix (1) in markdown parsing -- just look for empty lists succeeded by code blocks. Put the code blocks in the list, then coalesce any adjacent lists into a single list.

It's too late to fix (2) by the time we're dealing with the markdown AST, though. To deal with that, I preprocessed the markdown with a custom function that finds matching pairs of ` ``` `s in code and detects if the closing one is indented correctly.

Apparently Learn is very permissive when it comes to invalid markdown, which probably indicates it's doing custom processing on the text inside of `!options` tags, rather than parsing them as markdown first.

## Testing
To test in the PR build:
- [x] ?course=https%3A%2F%2Fraw.githubusercontent.com%2FAda-Developers-Academy%2Fcore%2Fmain%2Fcourse.yaml&section=Unit+1&standard=giOpFA&content-file-uid=3302a20d
- [x] ?course=https%3A%2F%2Fraw.githubusercontent.com%2FAda-Developers-Academy%2Fcore%2Fmain%2Fcourse.yaml&section=Unit+1&standard=w7RhPU&content-file-uid=692aeabdceb105d82aed2187db381860