### PR TITLE
fix(challenges): Support the new multiple choice format

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,7 +28,7 @@ export default function App() {
             </main>
             <footer className='dark-bg'>
               <nav className='link-section'>
-                <span>&copy;2023 Cyvaer</span>
+                <span>&copy;2026 Cyvaer</span>
                 <span>
                   <a href='https://github.com/cyvaer-llc/learn-viewer/issues/new/choose' target='_blank' rel='noreferrer'>
                     Report an issue

--- a/src/remark-plugins/remark-challenge-plugin/index.ts
+++ b/src/remark-plugins/remark-challenge-plugin/index.ts
@@ -83,6 +83,17 @@ function getAnswerIds(answer: Node[], challengeInfo: ChallengeInfo, mdToIdMap: M
     return mdToIdMap.get(markdown)!;
   }
 
+  // If the answer is like "a|" or "b|", we need to find that prefix in the list of mdToIDMap
+  if (is(answer[0], 'paragraph') && toMarkdown(unList(answer[0])).charAt(1) === '|') {
+    const correctAnswerPrefix = toMarkdown(unList(answer[0])).trimEnd();
+    for (const [answerMd, _] of mdToIdMap) {
+      if (answerMd.startsWith(correctAnswerPrefix)) {
+        return mdToIdMap.get(answerMd)!;
+      }
+    }
+    return [];
+  }
+
   // If this is a single paragraph node, that's the answer.
   if (answer.length === 1 && (is(answer[0], 'paragraph') || is(answer[0], 'code') || is(answer[0], 'text'))) {
     return [getAnswerId(answer[0] as Paragraph)];

--- a/src/remark-plugins/remark-challenge-plugin/make-option.ts
+++ b/src/remark-plugins/remark-challenge-plugin/make-option.ts
@@ -40,6 +40,21 @@ export function getList(nodes: Node[]): ListItem[] {
     return [];
   }
 
+  // The new format is a paragraph with a|, b|, etc
+  // Assume the first child of the paragraph is text and split its
+  // newline-separate entries up into list items.
+  if (nodes.length === 1 && nodes[0].type === 'paragraph') {
+    const pgph = nodes[0] as Paragraph;
+    if (pgph.children[0].type !== 'text') {
+      throw new Error("We only expect text to be in paragraphs for answers.");
+    }
+    const txt = pgph.children[0] as Text;
+    return txt.value.split('\n').map((value: string) => ({
+      type: 'listItem',
+      children: [{type: 'paragraph', children: [{type: 'text', value: value}] }]
+    }))
+  }
+
   if (nodes.length !== 1 || nodes[0].type !== 'list') {
     throw new Error('Expected a single list');
   }

--- a/src/remark-plugins/remark-challenge-plugin/md-to-js-parse.ts
+++ b/src/remark-plugins/remark-challenge-plugin/md-to-js-parse.ts
@@ -3,7 +3,7 @@
  * This file has parsers to turn the markdown into javascript objects.
  */
 import { Node  } from 'unist';
-import { List, ListItem, Text } from 'mdast';
+import { Html, List, ListItem, Text } from 'mdast';
 
 export type ChallengeInfo = {
   id: string,
@@ -22,6 +22,15 @@ export type ChallengeInfo = {
  * @returns a ChallengeInfo (id, title, and challengeType)
  */
 export function extractInfoNode(nodes: Node[]) : ChallengeInfo {
+  // Ignore any HTML comment nodes first
+  nodes = nodes.filter(node => {
+    if (node.type !== 'html') {
+      return true;
+    }
+    const html = node as Html;
+    return !(html.value.startsWith('<!--') && html.value.endsWith('-->'));
+  });
+
   if (nodes.length < 1 || nodes[0].type !== 'list') {
     throw new Error('First node in a challenge must be a list');
   }


### PR DESCRIPTION
# Summary
Two issues fixed:
1. The new C25 curriculum contained some HTML comments that showed up in the markdown abstract syntax tree. These don't add any value and don't need to be rendered, so the simplest solution is to ignore HTML comments.
2. Instead of rendering multiple-choice questions as lists, now they can be rendered in the markdown as `a| option 1\nb| option 2`. Also, answers can be listed as just `b|\n` instead of the full `b| option 2`. This change just generates list markdown ASTs from the newline-separated text and runs it through the original question-parsing code.

# Issues Addressed
- #25 
- #23 

# Testing
Tested locally using the new C25 curriculum. For example, this page was crashing and now it isn’t:

http://localhost:5173/?course=https%3A%2F%2Fgithub.com%2FAda-Developers-Academy%2Fcore%2Fblob%2Fmain%2Fc25%2Fcourse.yaml&section=Cloud+Infrastructure&standard=326f81ef-ca6c-4abb-a075-884258807cbf&content-file-uid=dd02607f-a1c4-43d4-83a0-1340865ab601