### PR TITLE
fix(challenges): Support multiple correct answers

### DIFF
--- a/src/remark-plugins/remark-challenge-plugin/index.ts
+++ b/src/remark-plugins/remark-challenge-plugin/index.ts
@@ -85,13 +85,14 @@ function getAnswerIds(answer: Node[], challengeInfo: ChallengeInfo, mdToIdMap: M
 
   // If the answer is like "a|" or "b|", we need to find that prefix in the list of mdToIDMap
   if (is(answer[0], 'paragraph') && toMarkdown(unList(answer[0])).charAt(1) === '|') {
-    const correctAnswerPrefix = toMarkdown(unList(answer[0])).trimEnd();
+    const correctAnswerPrefixes = toMarkdown(unList(answer[0])).trimEnd().split("\n");
+    const correctAnswerMds = [];
     for (const [answerMd, _] of mdToIdMap) {
-      if (answerMd.startsWith(correctAnswerPrefix)) {
-        return mdToIdMap.get(answerMd)!;
+      if (correctAnswerPrefixes.some(correctAnswerPrefix => answerMd.startsWith(correctAnswerPrefix))) {
+        correctAnswerMds.push(mdToIdMap.get(answerMd)!);
       }
     }
-    return [];
+    return correctAnswerMds;
   }
 
   // If this is a single paragraph node, that's the answer.


### PR DESCRIPTION
# Summary
Multiple correct answers like `a|\nc|` weren't being supported.

# Testing
- Open the [C25 Cloud Infrastructure Lesson](http://localhost:5173/?course=https%3A%2F%2Fgithub.com%2FAda-Developers-Academy%2Fcore%2Fblob%2Fmain%2Fc25%2Fcourse.yaml&section=Cloud+Infrastructure&standard=b45b570c-3a20-4117-b550-398b6a0d537f&content-file-uid=e57a44dc-c202-4bb8-87e7-d83e09473f85)
- Scroll to “Which of the following protocols operate at the Application Layer (Layer 7)?"
- Select `a` and `c`

## Before
<img width="400" alt="image" src="https://github.com/user-attachments/assets/b87f1a74-b109-4f39-bfd6-a2583102b9da" />


## After
<img width="400" alt="image" src="https://github.com/user-attachments/assets/f3b9a761-ee54-487c-ae6a-38e2bc0eecdf" />
