### PR TITLE
fix(checkboxes): Render markdown checklists instead of crashing

### DIFF
--- a/src/components/challenges/checkbox.tsx
+++ b/src/components/challenges/checkbox.tsx
@@ -11,5 +11,10 @@ export default function Checkbox(props: any) {
     toggleOption(evt.currentTarget.name);
   }, []);
 
+  if (!name) {
+    // If this checkbox isn't actually part of a challenge, just render a checkbox.
+    return (<input type="checkbox" />);
+  }
+
   return (<input {...props} checked={ selectors.isSelected(name) } type="checkbox" onChange={changed} />);
 }


### PR DESCRIPTION
# Summary
The checkbox component required `props.name`, but sometimes markdown provides checkbox AST nodes that are just parts of checklists, as opposed to needing to participate in challenge logic. The easiest way to handle that is to render a normal HTML checkbox when there's no `name`.

# Issues Addressed
* Crash in option ID parsing #7

# Testing
The Activity: Intro to SQL page should now render: http://localhost:5173/?course=https%3A%2F%2Fraw.githubusercontent.com%2FAda-Developers-Academy%2Fcore%2Fmain%2Fcourse.yaml&section=Unit+2&standard=3211fc3d75369f96b537a4535fcbba6d&content-file-uid=1ccd31d7b789d74e78d94c236193bb8d